### PR TITLE
Refactor main

### DIFF
--- a/controller/src/controller.rs
+++ b/controller/src/controller.rs
@@ -124,7 +124,10 @@ impl Controller {
         &self.state
     }
 
-    pub fn update_state(&mut self) -> bool {
+    /// Listen for the SDL events and updates the controller state when a controller event is received.
+    ///
+    /// Returns an error if the user has quit the application.
+    pub fn update_state(&mut self) -> Result<(), String> {
         let Sdl {
             controller_subsystem,
             event_pump,
@@ -137,12 +140,12 @@ impl Controller {
         for event in event_pump.poll_iter() {
             match event {
                 Event::Quit { .. } => {
-                    return false;
+                    return Err(String::from("Quit"));
                 }
                 Event::ControllerDeviceAdded { which, .. } => {
                     if controller_subsystem.num_joysticks().unwrap() > 1 {
                         println!(
-                            "More than one controller attached. Only one can be used at a time"
+                            "More than one controller was attached. Only one can be used at a time."
                         );
                     } else {
                         let new_controller = controller_subsystem.open(which).unwrap();
@@ -167,7 +170,7 @@ impl Controller {
             }
         }
 
-        true
+        Ok(())
     }
 }
 

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -25,10 +25,12 @@ pub fn main() {
     radio.print_rf_details();
 
     'running: loop {
-        let should_continue = controller.update_state();
-
-        if should_continue == false {
-            break 'running;
+        match controller.update_state() {
+            Ok(_) => {}
+            Err(e) => {
+                println!("Shutting down: {}", e);
+                break 'running;
+            }
         }
 
         let state = controller.get_state();


### PR DESCRIPTION
- Use variables at the top of the main function to improve the readability
- Remove unused sleep statement
- Change the return of the `update_state` function from `bool` to `Result<(), String>`